### PR TITLE
bash-completion: fix update) and ... in command list

### DIFF
--- a/contrib/tg-completion.bash
+++ b/contrib/tg-completion.bash
@@ -201,13 +201,14 @@ __tg_commands ()
 		return
 	fi
 	local i IFS=" "$'\n'
-	for i in $(tg help | sed -n 's/^Usage:.*(\(.*\)).*/\1/p' | tr '|' ' ')
+	for i in $(tg help | sed -n 's/^Usage:.*(\([^)]*\)).*/\1/p' | tr '|' ' ')
 	do
 		case $i in
 		*--*)             : helper pattern;;
 		*) echo $i;;
 		esac
 	done
+	echo help
 }
 __tg_all_commandlist=
 __tg_all_commandlist="$(__tg_commands 2>/dev/null)"


### PR DESCRIPTION
When deleting empty branch propagate its dependencies into dependent
branches unless -f was specified.
bor@opensuse:~> tg
...       delete    files     log       patch     remote
base      depend    import    mail      prev      summary
create    export    info      next      push      update)

Fix pattern to filter out command names.

While on it, add "help" to command completion list.

Signed-off-by: Andrey Borzenkov arvidjaar@gmail.com
