### PR TITLE
Fix tg.sh precheck test

### DIFF
--- a/tg.sh
+++ b/tg.sh
@@ -32,8 +32,8 @@ compare_versions()
 }
 
 precheck() {
-	git_ver=$(git version)
-	compare_versions . ${git_ver#git version} ${GIT_MINIMUM_VERSION} \
+	git_ver="$(git version | sed -e 's/^[^0-9][^0-9]*//')"
+	compare_versions . ${git_ver%%[!0-9.]*} ${GIT_MINIMUM_VERSION} \
 	    || die "git version >= " ${GIT_MINIMUM_VERSION} required
 }
 


### PR DESCRIPTION
Adjust the precheck version test so that it is
insensitive to case, translation and suffixes that
may be present in the output of the `git version`
command.

Some versions of Git are known to output a version
that looks like 'git version n.n.n.n (foo foo)'.

Without this fix those versions of Git do not pass
the check even though they should if the n.n.n.n
part is sufficiently recent.

Fixes issue #26
