### PR TITLE
Tg update custom merge

### DIFF
--- a/.topdeps
+++ b/.topdeps
@@ -1,0 +1,1 @@
+upstream

--- a/.topmsg
+++ b/.topmsg
@@ -1,0 +1,31 @@
+From: Ivan Zakharyaschev <imz@altlinux.org>
+Subject: [PATCH] tg_update-custom-merge
+
+Consider the problem of rebasing a TopGit (leaf) branch.
+
+A hypothetical "tg rebase-leaf" is like "git rebase tg-BASE"
+and is allowed only for leaves (not to break dependents).
+
+Let's think about a plan how it would work:
+
+* Find new-BASE (merging all dependencies into old-BASE).
+  - Note that old-BASE is a point whose history must not be rewritten.
+* Rebase old-BASE..HEAD onto new-BASE.
+  - BTW, "git rebase new-BASE" would automatically discover old-BASE.
+    as the common ancestor of new-BASE and HEAD.
+* Remove the ref for old-BASE.
+  - Well, actually, there is no need for keeping a ref like old-BASE
+    because "git rebase new-BASE" automatically discovers old-BASE.
+
+This must be very similar to the operation of "tg update",
+with the difference that "tg update" **merges** new-BASE into HEAD.
+
+I think a working solution would be to simply substitute
+"git rebase --preserve-merges" for "git merge" in "tg update".
+It might even work for recursive updates.
+-- https://github.com/greenrd/topgit/issues/40#issuecomment-74869975
+
+A hack is to pass it as an environment variable (instead of an option),
+which would also allow to satisfy another wish quickly:
+specifying special strategies (like -s ours) when updating special branches.
+-- https://github.com/greenrd/topgit/issues/42

--- a/README
+++ b/README
@@ -599,6 +599,27 @@ tg update
 	-r` (`tg summary` will point out branches with incomplete
 	dependencies by showing an '!' next to them).
 
+	You can use a different command instead of the default 'git merge'
+	when updating branches.
+
+	* If set, the environment variable TG_MERGE is the global
+	  default for all recursive invocations of `tg update`.
+
+	* But it can be overriden for the current branch with
+	  '--this-with CMD' option. (It is effective for the branches
+	  processed by the toplevel `tg update` process.)
+
+	This will help, if you want 'git merge -s ours' only into the
+	current branch. For example, with a custom message to attract
+	attention:
+
+	--this-with='git merge -s ours -m "merge -s ours"'
+
+	In contrast, if what you want to do with every processed
+	branch is to rebase, then you use:
+
+	TG_MERGE='git rebase --preserve-merges' tg update ...
+
 	TODO: tg update -a -c to autoremove (clean) up-to-date branches
 
 tg push

--- a/tg-update.sh
+++ b/tg-update.sh
@@ -18,6 +18,8 @@ while [ -n "$1" ]; do
 		all=1;;
 	--this-with)
 		TG_MERGE="$1"; shift;;
+	    # TODO: make it a configurable (and stored) option for each branch
+	    # (or perhaps pair of branches).
 	-*)
 		echo "Usage: tg [...] update [--this-with <merge-cmd>] ([<name>] | -a [<pattern>...])" >&2
 		exit 1;;

--- a/tg-update.sh
+++ b/tg-update.sh
@@ -180,8 +180,9 @@ update_branch() {
 		info "The $name head is up-to-date wrt. the base."
 		return 0
 	fi
-	info "Updating $name against new base..."
-	if ! git merge "$merge_with"; then
+	info "Updating $name against new base"
+	info "(with the cmd given by TG_MERGE if set: ${TG_MERGE:-git merge})..."
+	if ! ${TG_MERGE:-git merge} "$merge_with"; then
 		if [ -z "$TG_RECURSIVE" ]; then
 			info "Please commit merge resolution. No need to do anything else"
 			info "You can abort this operation using \`git reset --hard\` now"

--- a/tg-update.sh
+++ b/tg-update.sh
@@ -16,8 +16,10 @@ while [ -n "$1" ]; do
 	case "$arg" in
 	-a)
 		all=1;;
+	--this-with)
+		TG_MERGE="$1"; shift;;
 	-*)
-		echo "Usage: tg [...] update ([<name>] | -a [<pattern>...])" >&2
+		echo "Usage: tg [...] update [--this-with <merge-cmd>] ([<name>] | -a [<pattern>...])" >&2
 		exit 1;;
 	*)
 		if [ -z "$all" ]; then


### PR DESCRIPTION
I hacked tg-update to make it posisble to rebase (for the brave users). My work is in https://github.com/imz/topgit/compare/tg_update-custom-merge?expand=1.

But now, as I was pushing this, I had a thought about a possible issue I had not thought when implementing it:

What happens if git rebase stops to ask the user to resolve conflicts?

Well, thinking a bit about this issue, it appears to me that everything needed to handle this case must already be in the code, because git merge could also stop to ask to resolve conflicts. The user simply completes the operation, and the new HEAD ref is OK. (As for recursive updates, the code to handle this in subshells is also already there!)

Testing it in a simple case, it works! (Read my small changes to understand it better.)

$ tg update --this-with 'git rebase'
tg: Updating base with tg_rename changes...
Updating ee884ee..8436705
Fast-forward
README                            |  3 ++-
 tg-rename.sh => tg-rename-leaf.sh | 44 +++++++++++++++++++++++++++++++++++---------
 2 files changed, 37 insertions(+), 10 deletions(-)
 rename tg-rename.sh => tg-rename-leaf.sh (56%)
tg: Updating tg_rebase against new base (with the cmd given by TG_MERGE, by default: git merge...
First, rewinding head to replay your work on top of it...
Applying: (tg) create
Applying: (docs) A plan for what tg-rebase-leaf.sh should do.
Applying: A plan to implement it with a hack in tg update.
$ 

