### PR TITLE
Custom merge

### DIFF
--- a/.topdeps
+++ b/.topdeps
@@ -1,0 +1,1 @@
+upstream

--- a/.topmsg
+++ b/.topmsg
@@ -1,0 +1,31 @@
+From: Ivan Zakharyaschev <imz@altlinux.org>
+Subject: [PATCH] tg_update-custom-merge
+
+Consider the problem of rebasing a TopGit (leaf) branch.
+
+A hypothetical "tg rebase-leaf" is like "git rebase tg-BASE"
+and is allowed only for leaves (not to break dependents).
+
+Let's think about a plan how it would work:
+
+* Find new-BASE (merging all dependencies into old-BASE).
+  - Note that old-BASE is a point whose history must not be rewritten.
+* Rebase old-BASE..HEAD onto new-BASE.
+  - BTW, "git rebase new-BASE" would automatically discover old-BASE.
+    as the common ancestor of new-BASE and HEAD.
+* Remove the ref for old-BASE.
+  - Well, actually, there is no need for keeping a ref like old-BASE
+    because "git rebase new-BASE" automatically discovers old-BASE.
+
+This must be very similar to the operation of "tg update",
+with the difference that "tg update" **merges** new-BASE into HEAD.
+
+I think a working solution would be to simply substitute
+"git rebase --preserve-merges" for "git merge" in "tg update".
+It might even work for recursive updates.
+-- https://github.com/greenrd/topgit/issues/40#issuecomment-74869975
+
+A hack is to pass it as an environment variable (instead of an option),
+which would also allow to satisfy another wish quickly:
+specifying special strategies (like -s ours) when updating special branches.
+-- https://github.com/greenrd/topgit/issues/42

--- a/README
+++ b/README
@@ -247,6 +247,14 @@ tg create
 	dependency list, the topic branch is created based on the given
 	remote branch.
 
+	You can use a different command instead of the default 'git merge'
+	when updating or creating branches (see `tg update` for a full
+	description). For example, if you want to 'git merge -s ours' the
+	dependencies into the new branch, invoke the command with
+	(the custom message is to attract attention):
+
+	--this-with='git merge -s ours -m "merge -s ours"'
+
 tg delete
 ~~~~~~~~~
 	Remove a TopGit-controlled topic branch of the given name
@@ -600,14 +608,15 @@ tg update
 	dependencies by showing an '!' next to them).
 
 	You can use a different command instead of the default 'git merge'
-	when updating branches.
+	when updating or creating branches (TODO: or adding a new dependency).
 
 	* If set, the environment variable TG_MERGE is the global
-	  default for all recursive invocations of `tg update`.
+	  default for all recursive invocations of `tg update` 
+	  (as well as `tg create`).
 
 	* But it can be overriden for the current branch with
 	  '--this-with CMD' option. (It is effective for the branches
-	  processed by the toplevel `tg update` process.)
+	  processed by the toplevel `tg update` or `tg create` process.)
 
 	This will help, if you want 'git merge -s ours' only into the
 	current branch. For example, with a custom message to attract

--- a/README
+++ b/README
@@ -599,6 +599,27 @@ tg update
 	-r` (`tg summary` will point out branches with incomplete
 	dependencies by showing an '!' next to them).
 
+	You can use a different command instead of the default 'git merge'
+	when updating branches.
+
+	* If set, the environment variable TG_MERGE is the global
+	  default for all recursive invocations of `tg update`.
+
+	* But it can be overriden for the current branch with
+	  '--this-with CMD' option. (It is effective for the branches
+	  processed by the toplevel `tg update` process.)
+
+	This will help, if you want 'git merge -s ours' only into the
+	current branch. For example, with a custom message to attract
+	attention:
+
+	--this-with='git merge -s ours -m "merge -s ours"'
+
+	In contrast, if what you want to do with every processed
+	branch is to rebase, then you use:
+
+	TG_MERGE='git rebase --preserve-merges' tg update ...
+
 	TODO: tg update -a -c to autoremove (clean) up-to-date branches
 
 tg push

--- a/tg-create.sh
+++ b/tg-create.sh
@@ -17,8 +17,12 @@ while [ -n "$1" ]; do
 	case "$arg" in
 	-r)
 		rname="$1"; shift;;
+	--this-with)
+		TG_MERGE="$1"; shift;;
+	    # TODO: make it a configurable (and stored) option for each branch
+	    # (or perhaps pair of branches).
 	-*)
-		echo "Usage: tg [...] create [<name> [<dep>...|-r <rname>] ]" >&2
+		echo "Usage: tg [...] create [--this-with <merge-cmd>] [<name> [<dep>...|-r <rname>] ]" >&2
 		exit 1;;
 	*)
 		if [ -z "$name" ]; then
@@ -96,9 +100,10 @@ while [ -n "$merge" ]; do
 	# Unshift the first item from the to-merge list
 	branch="${merge%% *}"
 	merge="${merge#* }"
-	info "Merging $name base with $branch..."
+	info "Merging $name base with $branch"
+	info "(with the cmd given by TG_MERGE if set: ${TG_MERGE:-git merge})..."
 
-	if ! git merge "$branch"; then
+	if ! ${TG_MERGE:-git merge} "$branch"; then
 		info "Please commit merge resolution and call: $tg create"
 		info "It is also safe to abort this operation using:"
 		info "git reset --hard some_branch"

--- a/tg-update.sh
+++ b/tg-update.sh
@@ -18,6 +18,8 @@ while [ -n "$1" ]; do
 		all=1;;
 	--this-with)
 		TG_MERGE="$1"; shift;;
+	    # TODO: make it a configurable (and stored) option for each branch
+	    # (or perhaps pair of branches).
 	-*)
 		echo "Usage: tg [...] update [--this-with <merge-cmd>] ([<name>] | -a [<pattern>...])" >&2
 		exit 1;;

--- a/tg-update.sh
+++ b/tg-update.sh
@@ -180,8 +180,9 @@ update_branch() {
 		info "The $name head is up-to-date wrt. the base."
 		return 0
 	fi
-	info "Updating $name against new base..."
-	if ! git merge "$merge_with"; then
+	info "Updating $name against new base"
+	info "(with the cmd given by TG_MERGE if set: ${TG_MERGE:-git merge})..."
+	if ! ${TG_MERGE:-git merge} "$merge_with"; then
 		if [ -z "$TG_RECURSIVE" ]; then
 			info "Please commit merge resolution. No need to do anything else"
 			info "You can abort this operation using \`git reset --hard\` now"

--- a/tg-update.sh
+++ b/tg-update.sh
@@ -16,8 +16,10 @@ while [ -n "$1" ]; do
 	case "$arg" in
 	-a)
 		all=1;;
+	--this-with)
+		TG_MERGE="$1"; shift;;
 	-*)
-		echo "Usage: tg [...] update ([<name>] | -a [<pattern>...])" >&2
+		echo "Usage: tg [...] update [--this-with <merge-cmd>] ([<name>] | -a [<pattern>...])" >&2
 		exit 1;;
 	*)
 		if [ -z "$all" ]; then


### PR DESCRIPTION
A custom merge command is useful for the cases when we want [to rebase](https://github.com/greenrd/topgit/issues/40) or [to have a custom merge strategy](https://github.com/greenrd/topgit/issues/42).
- I'm quite happy now with `tg update --this-with 'git rebase --preserve-merges'`, which allows me not to clutter the branches I'm currently working on with numerous merges.
- I haven't yet tried to use `tg {update,create} --this-with 'git merge -s ours -m "merge -s ours"'` extensively (untested).
- I haven't tried (not that I remember) the recursive rebase with `TG_MERGE='git rebase --preserve-merges' tg update [--all]`.
- `tg depend add` should also get support for the custom merge (not implemented).

More comments at https://github.com/greenrd/topgit/issues/40#issuecomment-75737805.
