### PR TITLE
tg.sh (precheck): Mac OS X fix

### DIFF
--- a/tg.sh
+++ b/tg.sh
@@ -32,8 +32,8 @@ compare_versions()
 }
 
 precheck() {
-	git_ver=$(git version)
-	compare_versions . ${git_ver#git version} ${GIT_MINIMUM_VERSION} \
+	git_ver=$(git --version | cut -d' ' -f3)
+	compare_versions . ${git_ver} ${GIT_MINIMUM_VERSION} \
 	    || die "git version >= " ${GIT_MINIMUM_VERSION} required
 }
 


### PR DESCRIPTION
`git version` returns "git version 2.3.2 (Apple Git-55)" on my Mac OS X.
This caused `make` to fail:

    $ make
    [SED] tg
    ./tg precheck
    ./tg: line 29: [: (Apple: integer expression expected
    tg: fatal: git version >=  1.7.7.2 required
    make: *** [precheck] Error 1